### PR TITLE
Add nokogiri to the Gemspec

### DIFF
--- a/covid_pt.gemspec
+++ b/covid_pt.gemspec
@@ -29,5 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "sort_alphabetical"
   spec.add_dependency "pdf-reader"
   spec.add_dependency "rest-client"
+  spec.add_dependency "nokogiri"
   spec.add_development_dependency "rubocop"
 end


### PR DESCRIPTION
Currently, on a project without nokogiri by default, this gem is not working correctly.